### PR TITLE
Изменение контрольного блока компакта

### DIFF
--- a/include/ICompactControlBlock.h
+++ b/include/ICompactControlBlock.h
@@ -4,6 +4,14 @@
 
 class ICompactControlBlock {
 public:
+    /*
+    * Control block finds closest node to vector: val + shift, and stores this node elements in val
+    * 
+    * @param [in] shift Shift, that defines changes of iterator position
+    *
+    * @param [in] val Old iterator position, new position will be stored here
+    *
+    */
     virtual RC get(IVector const * const &shift, IVector * const&val) const = 0;
 
     virtual ~ICompactControlBlock() = 0

--- a/include/ICompactControlBlock.h
+++ b/include/ICompactControlBlock.h
@@ -1,11 +1,10 @@
 #pragma once
 #include "IVector.h"
-#include "IMultiIndex.h"
 #include <cstddef>
 
 class ICompactControlBlock {
 public:
-    virtual RC get(IMultiIndex * const& currentIndex, IVector const * const &shift, IVector * const&val) const = 0;
+    virtual RC get(IVector const * const &shift, IVector * const&val) const = 0;
 
     virtual ~ICompactControlBlock() = 0
 


### PR DESCRIPTION
Для упрощения и более адекватного учёта возможнотси смены сетки убираем мульти-индекс. Комментарий к методу добавил.